### PR TITLE
Refactor stun attributes

### DIFF
--- a/ice/src/lib.rs
+++ b/ice/src/lib.rs
@@ -75,11 +75,8 @@ fn udp_listener(address: IpAddr, key: String) -> Result<(SocketAddr, JoinHandle<
                 transaction_id: message.header.transaction_id,
             })
             .with_attributes(vec![
-                stun::Attribute::Username(username),
-                stun::Attribute::XorMappedAddress {
-                    address: src_addr.ip(),
-                    port: src_addr.port(),
-                },
+                stun::Attribute::username(username.as_str()),
+                stun::Attribute::xor_mapped_address(src_addr.ip(), src_addr.port()),
             ])
             .with_message_integrity(key.as_ref())
             .with_fingerprint()

--- a/stun/src/attribute/comprehension_optional.rs
+++ b/stun/src/attribute/comprehension_optional.rs
@@ -1,21 +1,19 @@
 use std::convert::TryInto;
 
-use nom::{
-    IResult,
-};
+use nom::IResult;
 
-use crate::attribute::Attribute;
+use crate::attribute::{Attribute, Tlv};
 
 #[derive(Debug, PartialEq)]
 pub struct ComprehensionOptional {
-    // TODO: implement type
-    // r#type: u32,
+    // TODO: implement typ
+    // typ: u32,
     value: Vec<u8>,
 }
 
-impl Attribute for ComprehensionOptional {
-    fn r#type(&self) -> u16 {
-        // TODO: replace with self.type
+impl Tlv for ComprehensionOptional {
+    fn typ(&self) -> u16 {
+        // TODO: replace with self.typ
         0x_0000
     }
 
@@ -28,9 +26,11 @@ impl Attribute for ComprehensionOptional {
     }
 }
 
-pub(crate) fn comprehension_optional(input: &[u8]) -> IResult<&[u8], impl Attribute> {
+pub(crate) fn comprehension_optional(input: &[u8]) -> IResult<&[u8], Attribute> {
     let value = input.to_vec();
-    let attribute = ComprehensionOptional { value };
+
+    let inner = ComprehensionOptional { value };
+    let attribute = Attribute::ComprehensionOptional(inner);
 
     Ok((&[], attribute))
 }

--- a/stun/src/attribute/fingerprint.rs
+++ b/stun/src/attribute/fingerprint.rs
@@ -1,16 +1,14 @@
 use std::convert::TryInto;
 
-use nom::{
-    IResult,
-};
+use nom::IResult;
 
-use crate::attribute::Attribute;
+use crate::attribute::{Attribute, Tlv};
 
 #[derive(Debug, PartialEq)]
 pub struct Fingerprint(pub u32);
 
-impl Attribute for Fingerprint {
-    fn r#type(&self) -> u16 {
+impl Tlv for Fingerprint {
+    fn typ(&self) -> u16 {
         0x_8028
     }
 
@@ -23,11 +21,13 @@ impl Attribute for Fingerprint {
     }
 }
 
-pub(crate) fn fingerprint(input: &[u8]) -> IResult<&[u8], impl Attribute> {
+pub(crate) fn fingerprint(input: &[u8]) -> IResult<&[u8], Attribute> {
     let (input, remainder) = input.split_at(4);
     let input: [u8; 4] = input.try_into().unwrap();
     let value = u32::from_be_bytes(input);
-    let attribute = Fingerprint(value);
+
+    let inner = Fingerprint(value);
+    let attribute = Attribute::Fingerprint(inner);
 
     Ok((remainder, attribute))
 }

--- a/stun/src/attribute/message_integrity.rs
+++ b/stun/src/attribute/message_integrity.rs
@@ -1,16 +1,20 @@
 use std::convert::TryInto;
 
-use nom::{
-    IResult,
-};
+use nom::IResult;
 
-use crate::attribute::Attribute;
+use crate::attribute::{Attribute, Tlv};
 
 #[derive(Debug, PartialEq)]
-pub struct MessageIntegrity(pub Vec<u8>);
+pub struct MessageIntegrity(Vec<u8>);
 
-impl Attribute for MessageIntegrity {
-    fn r#type(&self) -> u16 {
+impl MessageIntegrity {
+    pub fn new(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
+impl Tlv for MessageIntegrity {
+    fn typ(&self) -> u16 {
         0x_0008
     }
 
@@ -23,9 +27,12 @@ impl Attribute for MessageIntegrity {
     }
 }
 
-pub(crate) fn message_integrity(input: &[u8]) -> IResult<&[u8], impl Attribute> {
+pub(crate) fn message_integrity(input: &[u8]) -> IResult<&[u8], Attribute> {
     let (input, remainder) = input.split_at(20);
-    let attribute = MessageIntegrity(input.to_vec());
+    let value = input.to_vec();
+
+    let inner = MessageIntegrity(value);
+    let attribute = Attribute::MessageIntegrity(inner);
 
     Ok((remainder, attribute))
 }

--- a/stun/src/attribute/mod.rs
+++ b/stun/src/attribute/mod.rs
@@ -5,26 +5,25 @@ mod priority;
 mod username;
 mod xor_mapped_address;
 
+use std::net::IpAddr;
+
 use log::trace;
 use nom::{
-    combinator::all_consuming,
-    multi::length_data,
-    number::complete::be_u16,
-    sequence::tuple,
+    combinator::all_consuming, multi::length_data, number::complete::be_u16, sequence::tuple,
     IResult,
 };
 
 use crate::attribute::{
-    comprehension_optional::comprehension_optional,
-    fingerprint::fingerprint,
-    message_integrity::message_integrity,
-    priority::priority,
-    username::username,
-    xor_mapped_address::xor_mapped_address,
+    comprehension_optional::{comprehension_optional, ComprehensionOptional},
+    fingerprint::{fingerprint, Fingerprint},
+    message_integrity::{message_integrity, MessageIntegrity},
+    priority::{priority, Priority},
+    username::{username, Username},
+    xor_mapped_address::{xor_mapped_address, XorMappedAddress},
 };
 
-pub trait Attribute: std::fmt::Debug + std::cmp::PartialEq {
-    fn r#type(&self) -> u16;
+pub trait Tlv {
+    fn typ(&self) -> u16;
 
     fn length(&self) -> u16;
 
@@ -33,13 +32,72 @@ pub trait Attribute: std::fmt::Debug + std::cmp::PartialEq {
     fn to_bytes(&self) -> Vec<u8> {
         let value_field = self.value();
         let length_field = self.length().to_be_bytes();
-        let type_field = self.r#type().to_be_bytes();
+        let type_field = self.typ().to_be_bytes();
 
         let mut bytes = type_field.to_vec();
         bytes.extend_from_slice(&length_field);
         bytes.extend_from_slice(&value_field);
 
         bytes
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Attribute {
+    ComprehensionOptional(ComprehensionOptional),
+    Fingerprint(Fingerprint),
+    MessageIntegrity(MessageIntegrity),
+    Priority(Priority),
+    Username(Username),
+    XorMappedAddress(XorMappedAddress),
+}
+
+impl Attribute {
+    pub fn username(value: &str) -> Self {
+        let inner = Username::new(value);
+
+        Attribute::Username(inner)
+    }
+
+    pub fn xor_mapped_address(address: IpAddr, port: u16) -> Self {
+        let inner = XorMappedAddress::new(address, port);
+
+        Attribute::XorMappedAddress(inner)
+    }
+}
+
+impl Tlv for Attribute {
+    fn typ(&self) -> u16 {
+        match self {
+            Attribute::ComprehensionOptional(inner) => inner.typ(),
+            Attribute::Fingerprint(inner) => inner.typ(),
+            Attribute::MessageIntegrity(inner) => inner.typ(),
+            Attribute::Priority(inner) => inner.typ(),
+            Attribute::Username(inner) => inner.typ(),
+            Attribute::XorMappedAddress(inner) => inner.typ(),
+        }
+    }
+
+    fn length(&self) -> u16 {
+        match self {
+            Attribute::ComprehensionOptional(inner) => inner.length(),
+            Attribute::Fingerprint(inner) => inner.length(),
+            Attribute::MessageIntegrity(inner) => inner.length(),
+            Attribute::Priority(inner) => inner.length(),
+            Attribute::Username(inner) => inner.length(),
+            Attribute::XorMappedAddress(inner) => inner.length(),
+        }
+    }
+
+    fn value(&self) -> Vec<u8> {
+        match self {
+            Attribute::ComprehensionOptional(inner) => inner.value(),
+            Attribute::Fingerprint(inner) => inner.value(),
+            Attribute::MessageIntegrity(inner) => inner.value(),
+            Attribute::Priority(inner) => inner.value(),
+            Attribute::Username(inner) => inner.value(),
+            Attribute::XorMappedAddress(inner) => inner.value(),
+        }
     }
 }
 
@@ -54,7 +112,7 @@ pub trait Attribute: std::fmt::Debug + std::cmp::PartialEq {
 //               Figure 4: Format of STUN Attributes
 //
 // https://tools.ietf.org/html/rfc5389#section-15
-pub(crate) fn attribute(input: &[u8]) -> IResult<&[u8], Box<Attribute>> {
+pub(crate) fn attribute(input: &[u8]) -> IResult<&[u8], Attribute> {
     let (remainder, (typ_field, value_field)) = tuple((be_u16, length_data(be_u16)))(input)?;
 
     let pad_len = (4 - (value_field.len() % 4)) % 4;
@@ -97,5 +155,5 @@ pub(crate) fn attribute(input: &[u8]) -> IResult<&[u8], Box<Attribute>> {
     };
     let (_, attribute) = all_consuming(parser)(value_field)?;
 
-    Ok((remainder, Box::new(attribute)))
+    Ok((remainder, attribute))
 }

--- a/stun/src/attribute/priority.rs
+++ b/stun/src/attribute/priority.rs
@@ -1,16 +1,14 @@
 use std::convert::TryInto;
 
-use nom::{
-    IResult,
-};
+use nom::IResult;
 
-use crate::attribute::Attribute;
+use crate::attribute::{Attribute, Tlv};
 
 #[derive(Debug, PartialEq)]
-struct Priority(u32);
+pub struct Priority(u32);
 
-impl Attribute for Priority {
-    fn r#type(&self) -> u16 {
+impl Tlv for Priority {
+    fn typ(&self) -> u16 {
         0x_0024
     }
 
@@ -23,11 +21,13 @@ impl Attribute for Priority {
     }
 }
 
-pub(crate) fn priority(input: &[u8]) -> IResult<&[u8], impl Attribute> {
+pub(crate) fn priority(input: &[u8]) -> IResult<&[u8], Attribute> {
     let (input, remainder) = input.split_at(4);
     let input: [u8; 4] = input.try_into().unwrap();
     let value = u32::from_be_bytes(input);
-    let attribute = Priority(value);
+
+    let inner = Priority(value);
+    let attribute = Attribute::Priority(inner);
 
     Ok((remainder, attribute))
 }

--- a/stun/src/attribute/username.rs
+++ b/stun/src/attribute/username.rs
@@ -1,16 +1,24 @@
 use std::convert::TryInto;
 
-use nom::{
-    IResult,
-};
+use nom::IResult;
 
-use crate::attribute::Attribute;
+use crate::attribute::{Attribute, Tlv};
 
 #[derive(Debug, PartialEq)]
-struct Username(String);
+pub struct Username(String);
 
-impl Attribute for Username {
-    fn r#type(&self) -> u16 {
+impl Username {
+    pub fn new(username: &str) -> Self {
+        Self(username.to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Tlv for Username {
+    fn typ(&self) -> u16 {
         0x_0006
     }
 
@@ -23,11 +31,13 @@ impl Attribute for Username {
     }
 }
 
-pub(crate) fn username(input: &[u8]) -> IResult<&[u8], impl Attribute> {
+pub(crate) fn username(input: &[u8]) -> IResult<&[u8], Attribute> {
     // TODO: check the input length is < 513
     // TODO: return Err here
     let value = String::from_utf8(input.to_vec()).unwrap();
-    let attribute = Username(value);
+
+    let inner = Username(value);
+    let attribute = Attribute::Username(inner);
 
     Ok((&[], attribute))
 }


### PR DESCRIPTION
It's easier to reason about if the attributes are in a dedicated module. The PR attempts to achieve this by going one step further and having each attribute as its own submodule of an attributes module. We also attempt to make the ergonomics of attributes better through the use of traits.